### PR TITLE
Default to TFramedTransportFactory

### DIFF
--- a/gevent_thrift/server.py
+++ b/gevent_thrift/server.py
@@ -62,9 +62,9 @@ class ThriftServer(StreamServer):
         self.log = log
         self.processor = processor
         self.inputTransportFactory = (inputTransportFactory
-            or TTransport.TTransportFactoryBase())
+            or TTransport.TFramedTransportFactory())
         self.outputTransportFactory = (outputTransportFactory
-            or TTransport.TTransportFactoryBase())
+            or TTransport.TFramedTransportFactory())
         self.inputProtocolFactory = (inputProtocolFactory
             or TBinaryProtocol.TBinaryProtocolFactory())
         self.outputProtocolFactory = (outputProtocolFactory


### PR DESCRIPTION
As far as I can see we always use framed transport in monitor, so it might be a reasonable default. From the name it doesn't sound like TTransportFactoryBased should be used directly. Anyone knowledgable about this?
