### PR TITLE
Add install dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-kwargs = {
-    'name': 'gevent-thrift',
-    'version': '0.1',
-    'description': 'gevent bindings for Thrift',
-    'author': 'Edgeware AB',
-    'author_email': 'info@edgeware.tv',
-    'url': 'https://github.com/edgeware/gevent-thrift',
-    'packages': ['gevent_thrift'],
-    'install_requires': [
-        'gevent==1.0',
-        'thrift==0.8.0'
-    ]
-}
-
-setup(**kwargs)
+setup(name='gevent-thrift',
+      version='0.1',
+      description='Gevent bindings for Thrift',
+      author='Edgeware AB',
+      author_email='info@edgeware.tv',
+      url='https://github.com/edgeware/gevent-thrift',
+      packages=['gevent_thrift'],
+      install_requires=[
+          'gevent==1.0',
+          'thrift==0.8.0'
+      ])


### PR DESCRIPTION
Tweaks to `setup.py`.

---

https://github.com/edgeware/gevent-thrift/pull/2 (this)
https://github.com/edgeware/gevent-kafka/pull/6 (merged)
<del>https://github.com/edgeware/gevent-zookeeper/pull/4</del> (closed, deprecated)
https://github.com/edgeware/gevent-server/pull/10 (merged)
